### PR TITLE
Fix validation for amount and currency.

### DIFF
--- a/src/Message/PeriodicTriggerPaymentRequest.php
+++ b/src/Message/PeriodicTriggerPaymentRequest.php
@@ -104,7 +104,7 @@ final class PeriodicTriggerPaymentRequest extends PeriodicAbstractRequest
     public function getData()
     {
         $data = $this->getBaseData();
-        $this->validate(['customerReference', 'transactionReference', 'transactionAmount', 'transactionCurrency']);
+        $this->validate(['customerReference', 'transactionReference', 'amount', 'currency']);
         $data['Transaction'] = [
             'Amount' => $this->getAmountInteger(),
             'Currency' => $this->getCurrency(),


### PR DESCRIPTION
It's should validate standard omnipay amount and currency parameters, not transactionAmount, transactionCurrency.
